### PR TITLE
Add request body to the exception

### DIFF
--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -87,19 +87,18 @@ class DnsMadeEasy
     unparsed_json = response.body == "" ? "{}" : response.body
     JSON.parse(unparsed_json)
   rescue => e
-    if response.present?
-      raise CreateRecordException.new(response.to_hash, unparsed_json), e.message
-    else
-      raise
-    end
+    raise if response.body.strip.empty?
+    fail CreateRecordException.new(response.to_hash, unparsed_json, body, e.message)
   end
 
   class CreateRecordException < StandardError
-    attr_accessor :response_headers, :response_body
+    attr_accessor :response_headers, :response_body, :request_body
 
-    def initialize(response_headers, response_body)
+    def initialize(response_headers, response_body, request_body, message)
       @response_headers = response_headers
       @response_body = response_body
+      @request_body = request_body
+      super(message)
     end
   end
 


### PR DESCRIPTION
@3dna/trogbots 

Since I just told you about this, here's the pull request to add more information to the exception we generate. This is typically because the JSON.parse chokes on html that they send us, which means that they have 500'ed. They want me to capture the request body so that's what I'm doing here.

This will be followed by an nbuild pull request to incorporate logging that data to honeybadger.
