### PR TITLE
use query params to filter name and type on DME servers

### DIFF
--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -56,17 +56,18 @@ class DnsMadeEasy
 
   def records_for(domain_name, options={})
     query_params = options_to_params(options)
+
     get "/dns/managed/#{get_id_by_domain(domain_name)}/records?#{query_params}"
   end
 
   def find(domain_name, name, type)
-    records = records_for(domain_name, {name: name, type: type})
+    records = records_for(domain_name, name: name, type: type)
 
     records['data'].first
   end
 
   def find_record_id(domain_name, name, type)
-    records = records_for(domain_name, {name: name, type: type})
+    records = records_for(domain_name, name: name, type: type)
 
     records['data'].map{ |r| r['id'] }
   end

--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -59,15 +59,15 @@ class DnsMadeEasy
   end
 
   def find(domain_name, name, type)
-    records = records_for(domain_name)
-    records['data'].detect { |r| r['name'] == name && r['type'] == type }
+    records = get "/dns/managed/#{get_id_by_domain(domain_name)}/records?recordName=#{name}&type=#{type}"
+
+    records['data'].first
   end
 
   def find_record_id(domain_name, name, type)
-    records = records_for(domain_name)
+    records = get "/dns/managed/#{get_id_by_domain(domain_name)}/records?recordName=#{name}&type=#{type}"
 
-    records['data'].select { |r| r['name'] == name && r['type'] == type }
-                   .map    { |r| r['id'] }
+    records['data'].map{ |r| r['id'] }
   end
 
   def delete_records(domain_name, ids = [])
@@ -144,7 +144,7 @@ class DnsMadeEasy
 
   def get(path)
     request(path) do |uri|
-      Net::HTTP::Get.new(uri.path)
+      Net::HTTP::Get.new(uri)
     end
   end
 

--- a/spec/lib/dnsmadeeasyapi-rest-api_spec.rb
+++ b/spec/lib/dnsmadeeasyapi-rest-api_spec.rb
@@ -112,7 +112,7 @@ describe DnsMadeEasy do
   end
 
   describe '#find' do
-    let(:records_for_response) do
+    let(:response) do
       {
         'data' => [
           { 'name' => 'demo', 'type' => 'A', 'id' => 123},
@@ -122,16 +122,20 @@ describe DnsMadeEasy do
     end
 
     before do
-      subject.stub(:records_for).with('something.wanelo.com').and_return(records_for_response)
+      subject.stub(:get_id_by_domain).with('something.wanelo.com').and_return(123)
     end
 
     it 'finds the first record that matches name and type' do
+      stub_request(:get, "https://api.dnsmadeeasy.com/V2.0/dns/managed/123/records?recordName=demo&type=A").
+        with(:headers => request_headers).
+        to_return(:status => 200, :body => response.to_json, :headers => {})
+
       expect(subject.find('something.wanelo.com', 'demo', 'A')).to eq({ 'name' => 'demo', 'type' => 'A', 'id' => 123})
     end
   end
 
   describe '#find_record_id' do
-    let(:records_for_response) do
+    let(:response) do
       {
         'data' => [
           { 'name' => 'demo', 'type' => 'A', 'id' => 123},
@@ -141,10 +145,14 @@ describe DnsMadeEasy do
     end
 
     before do
-      subject.stub(:records_for).with('something.wanelo.com').and_return(records_for_response)
+      subject.stub(:get_id_by_domain).with('something.wanelo.com').and_return(123)
     end
 
     it 'finds the specified record given a name and a type' do
+      stub_request(:get, "https://api.dnsmadeeasy.com/V2.0/dns/managed/123/records?recordName=demo&type=A").
+        with(:headers => request_headers).
+        to_return(:status => 200, :body => response.to_json, :headers => {})
+
       expect(subject.find_record_id('something.wanelo.com', 'demo', 'A')).to eq([123, 143])
     end
   end

--- a/spec/lib/dnsmadeeasyapi-rest-api_spec.rb
+++ b/spec/lib/dnsmadeeasyapi-rest-api_spec.rb
@@ -96,8 +96,6 @@ describe DnsMadeEasy do
   end
 
   describe '#records_for' do
-    let(:response) { "{}" }
-
     before do
       subject.stub(:get_id_by_domain).with('something.wanelo.com').and_return(123)
     end
@@ -105,9 +103,43 @@ describe DnsMadeEasy do
     it 'returns all records for a given domain' do
       stub_request(:get, "https://api.dnsmadeeasy.com/V2.0/dns/managed/123/records").
         with(:headers => request_headers).
-        to_return(:status => 200, :body => response, :headers => {})
+        to_return(:status => 200, :body => "{}", :headers => {})
 
       expect(subject.records_for('something.wanelo.com')).to eq({})
+    end
+
+    context 'filters' do
+      let(:response) {{
+        'data' => [
+          { 'name' => 'demo', 'type' => 'A', 'id' => 123},
+          { 'name' => 'demo', 'type' => 'A', 'id' => 143}
+        ]
+      }}
+
+      it 'returns filtered records for a given domain' do
+        stub_request(:get, "https://api.dnsmadeeasy.com/V2.0/dns/managed/123/records?type=A&recordName=demo").
+          with(:headers => request_headers).
+          to_return(:status => 200, :body => response.to_json, :headers => {})
+
+        expect(subject.records_for('something.wanelo.com', name: 'demo', type: 'A')).to eq(response)
+      end
+
+      it 'returns filtered records with just the type' do
+        stub_request(:get, "https://api.dnsmadeeasy.com/V2.0/dns/managed/123/records?type=A").
+          with(:headers => request_headers).
+          to_return(:status => 200, :body => response.to_json, :headers => {})
+
+        expect(subject.records_for('something.wanelo.com', type: 'A')).to eq(response)
+      end
+
+      it 'returns filtered records with just the name' do
+
+          stub_request(:get, "https://api.dnsmadeeasy.com/V2.0/dns/managed/123/records?recordName=demo").
+            with(:headers => request_headers).
+            to_return(:status => 200, :body => response.to_json, :headers => {})
+
+          expect(subject.records_for('something.wanelo.com', name: 'demo')).to eq(response)
+      end
     end
   end
 
@@ -126,7 +158,7 @@ describe DnsMadeEasy do
     end
 
     it 'finds the first record that matches name and type' do
-      stub_request(:get, "https://api.dnsmadeeasy.com/V2.0/dns/managed/123/records?recordName=demo&type=A").
+      stub_request(:get, "https://api.dnsmadeeasy.com/V2.0/dns/managed/123/records?type=A&recordName=demo").
         with(:headers => request_headers).
         to_return(:status => 200, :body => response.to_json, :headers => {})
 
@@ -149,7 +181,7 @@ describe DnsMadeEasy do
     end
 
     it 'finds the specified record given a name and a type' do
-      stub_request(:get, "https://api.dnsmadeeasy.com/V2.0/dns/managed/123/records?recordName=demo&type=A").
+      stub_request(:get, "https://api.dnsmadeeasy.com/V2.0/dns/managed/123/records?type=A&recordName=demo").
         with(:headers => request_headers).
         to_return(:status => 200, :body => response.to_json, :headers => {})
 


### PR DESCRIPTION
This approach is much faster, and reduces the amount of data that needs to be loaded, parsed, and then thrown away.

Documentation is located: https://www.dnsmadeeasy.com/pdf/API-Docv2.pdf